### PR TITLE
fix(dashboard): guard against showing predicted values as results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,5 +69,3 @@ venv/
 *.sqlite
 *.sqlite3
 # predictions/
-claude-md-review-prompt.md
-update-claude-md.yml

--- a/src/components/generated/DashboardScreen.tsx
+++ b/src/components/generated/DashboardScreen.tsx
@@ -121,17 +121,9 @@ export function DashboardScreen() {
             setAiAnalysis(aiData.market_context || null);
             setLocked(true);
             
-            // Update price predictions with proper rounding
-            setKeyTimes(prev => prev.map(item => {
-              const pred = aiData.predictions.find((p: any) => 
-                p.checkpoint.toLowerCase() === item.label.toLowerCase() ||
-                (p.checkpoint === 'twoPM' && item.label === '2:00')
-              );
-              return { 
-                ...item, 
-                price: pred?.predicted_price ? Math.round(pred.predicted_price * 100) / 100 : null 
-              };
-            }));
+            // IMPORTANT: Do NOT populate Key Times with predicted values.
+            // These slots display actuals only as the day unfolds.
+            setKeyTimes(prev => prev.map(item => ({ ...item, price: null })));
           } catch (aiError) {
             // Final fallback: attempt a best-effort create if after 8:00 CST
             try {


### PR DESCRIPTION
- Do not populate Key Times with AI predicted prices; only show when actuals exist.\n- Keeps band/analysis unchanged.\n- Chart already ignores nulls; no change there.\n\nCloses #14.